### PR TITLE
M2 Mac用のsettingを追加

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -36,6 +36,9 @@ gem 'bootsnap', require: false
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 gem 'rack-cors'
 
+# for m1 mac
+gem 'nokogiri'
+
 group :development, :test do
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem "rspec-rails"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -118,6 +118,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.8-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.13.8-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.8-x86_64-linux)
@@ -218,6 +220,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  aarch64-linux
   x86_64-darwin-21
   x86_64-linux
 
@@ -226,6 +229,7 @@ DEPENDENCIES
   debug
   factory_bot_rails
   mysql2 (~> 0.5)
+  nokogiri
   puma (~> 5.0)
   rack-cors
   rails (~> 7.0.3, >= 7.0.3.1)

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:15.8
+FROM node:16.10.0
 
 ENV APP /usr/src/app
 RUN mkdir $APP

--- a/frontend/app/yarn.lock
+++ b/frontend/app/yarn.lock
@@ -1847,7 +1847,7 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@pmmmwh/react-refresh-webpack-plugin@^0.5.3", "@pmmmwh/react-refresh-webpack-plugin@^0.5.7":
+"@pmmmwh/react-refresh-webpack-plugin@^0.5.3":
   version "0.5.7"
   resolved "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.7.tgz"
   integrity sha512-bcKCAzF0DV2IIROp9ZHkRJa6O4jy7NlnHdWL3GmcUxYWNjLXkK5kfELELwEfSP5hXPfVL/qOGMAROuMQb9GG8Q==

--- a/frontend/node_modules/.yarn-integrity
+++ b/frontend/node_modules/.yarn-integrity
@@ -1,0 +1,10 @@
+{
+  "systemParams": "linux-arm64-93",
+  "modulesFolders": [],
+  "flags": [],
+  "linkedModules": [],
+  "topLevelPatterns": [],
+  "lockfileEntries": {},
+  "files": [],
+  "artifacts": {}
+}


### PR DESCRIPTION
M2だとbackendにnokogiriがないと、frontのnodeが16.10.0でないと動かなかったので、設定を追加させていただきました。

tomoさんの手元で動かせたら、マージお願いします！